### PR TITLE
Set empty bytestring as default for tags

### DIFF
--- a/aioriak/tests/test_kv.py
+++ b/aioriak/tests/test_kv.py
@@ -77,15 +77,32 @@ class BasicKVTests(IntegrationTest, AsyncUnitTestCase):
             await sub_obj.store()
 
             main_obj = await bucket.new('main', rand)
-            link_entry = (
-                bucket.name.encode('ascii'),
-                sub_obj.key.encode('ascii'),
-                b'foobarbaz'
-            )
+            link_entry = (bucket.name, sub_obj.key, 'foobarbaz')
             main_obj.links.append(link_entry)
             await main_obj.store()
             fetched_main_obj = await bucket.get('main')
             self.assertEqual(fetched_main_obj.links, [link_entry])
+        self.loop.run_until_complete(go())
+
+    def test_store_with_links_with_byte_fields(self):
+        async def go():
+            bucket = self.client.bucket(self.bucket_name)
+            rand = self.randint()
+            sub_obj = await bucket.new('sub', rand)
+            await sub_obj.store()
+
+            main_obj = await bucket.new('main', rand)
+            link_entry = (
+                bucket.name.encode(),
+                sub_obj.key.encode(),
+                b'foobarbaz'
+            )
+            main_obj.links.append(link_entry)
+            with self.assertWarns(DeprecationWarning):
+                await main_obj.store()
+            fetched_main_obj = await bucket.get('main')
+            expected_entry = (bucket.name, sub_obj.key, 'foobarbaz')
+            self.assertEqual(fetched_main_obj.links, [expected_entry])
         self.loop.run_until_complete(go())
 
     def test_store_with_links_without_tag(self):
@@ -96,19 +113,11 @@ class BasicKVTests(IntegrationTest, AsyncUnitTestCase):
             await sub_obj.store()
 
             main_obj = await bucket.new('main', rand)
-            link_entry = (
-                bucket.name.encode('ascii'),
-                sub_obj.key.encode('ascii'),
-                None
-            )
+            link_entry = (bucket.name, sub_obj.key, None)
             main_obj.links.append(link_entry)
             await main_obj.store()
             fetched_main_obj = await bucket.get('main')
-            expected_entry = (
-                bucket.name.encode('ascii'),
-                sub_obj.key.encode('ascii'),
-                b''  # Tag should default to an empty bytestring
-            )
+            expected_entry = (bucket.name, sub_obj.key, '')
             self.assertEqual(fetched_main_obj.links, [expected_entry])
         self.loop.run_until_complete(go())
 

--- a/aioriak/tests/test_kv.py
+++ b/aioriak/tests/test_kv.py
@@ -104,7 +104,12 @@ class BasicKVTests(IntegrationTest, AsyncUnitTestCase):
             main_obj.links.append(link_entry)
             await main_obj.store()
             fetched_main_obj = await bucket.get('main')
-            self.assertEqual(fetched_main_obj.links, [link_entry])
+            expected_entry = (
+                bucket.name.encode('ascii'),
+                sub_obj.key.encode('ascii'),
+                b''  # Tag should default to an empty bytestring
+            )
+            self.assertEqual(fetched_main_obj.links, [expected_entry])
         self.loop.run_until_complete(go())
 
     def test_store_object_with_unicode(self):

--- a/aioriak/tests/test_kv.py
+++ b/aioriak/tests/test_kv.py
@@ -69,6 +69,44 @@ class BasicKVTests(IntegrationTest, AsyncUnitTestCase):
             self.assertEqual(obj2.data, rand)
         self.loop.run_until_complete(go())
 
+    def test_store_with_links_with_explicit_tag(self):
+        async def go():
+            bucket = self.client.bucket(self.bucket_name)
+            rand = self.randint()
+            sub_obj = await bucket.new('sub', rand)
+            await sub_obj.store()
+
+            main_obj = await bucket.new('main', rand)
+            link_entry = (
+                bucket.name.encode('ascii'),
+                sub_obj.key.encode('ascii'),
+                b'foobarbaz'
+            )
+            main_obj.links.append(link_entry)
+            await main_obj.store()
+            fetched_main_obj = await bucket.get('main')
+            self.assertEqual(fetched_main_obj.links, [link_entry])
+        self.loop.run_until_complete(go())
+
+    def test_store_with_links_without_tag(self):
+        async def go():
+            bucket = self.client.bucket(self.bucket_name)
+            rand = self.randint()
+            sub_obj = await bucket.new('sub', rand)
+            await sub_obj.store()
+
+            main_obj = await bucket.new('main', rand)
+            link_entry = (
+                bucket.name.encode('ascii'),
+                sub_obj.key.encode('ascii'),
+                None
+            )
+            main_obj.links.append(link_entry)
+            await main_obj.store()
+            fetched_main_obj = await bucket.get('main')
+            self.assertEqual(fetched_main_obj.links, [link_entry])
+        self.loop.run_until_complete(go())
+
     def test_store_object_with_unicode(self):
         async def go():
             bucket = self.client.bucket(self.bucket_name)

--- a/aioriak/transport.py
+++ b/aioriak/transport.py
@@ -246,7 +246,7 @@ class RiakPbcAsyncTransport:
             if tag:
                 pb_link.tag = tag
             else:
-                pb_link.tag = ''
+                pb_link.tag = b''
 
         for field, value in robj.indexes:
             if isinstance(value, int):


### PR DESCRIPTION
When using links and not adding an explicit tag to the link entry, the library will default to using an empty string, whilst the protobuf package validates that this is a bytestring. This pull request adds two tests for adding links with explicit tags and without and changes the default link tag to an empty bytestring.