### PR TITLE
Add Python 3.7 support.

### DIFF
--- a/aioriak/tests/test_kv.py
+++ b/aioriak/tests/test_kv.py
@@ -4,9 +4,10 @@ from aioriak.mapreduce import RiakMapReduce
 from aioriak.error import ConflictError
 from aioriak.resolver import default_resolver, last_written_resolver
 import asyncio
+import copy
 import json
 import pickle
-import copy
+import riak
 
 
 testrun_props_bucket = 'propsbucket'
@@ -662,7 +663,11 @@ class BasicKVTests(IntegrationTest, AsyncUnitTestCase):
                                     {'foo': 'two', 'bar': 'green'})).store()
 
             mr = RiakMapReduce(self.client)
-            mr.add_bucket(self.bucket_name)
+            try:
+                riak.disable_list_exceptions = True
+                mr.add_bucket(self.bucket_name)
+            finally:
+                riak.disable_list_exceptions = False
 
             mr.map(['riak_kv_mapreduce', 'map_object_value'])
 
@@ -681,7 +686,12 @@ class BasicKVTests(IntegrationTest, AsyncUnitTestCase):
                                     {'foo': 'two', 'bar': 'green'})).store()
 
             mr = RiakMapReduce(self.client)
-            mr.add_bucket(self.bucket_name)
+
+            try:
+                riak.disable_list_exceptions = True
+                mr.add_bucket(self.bucket_name)
+            finally:
+                riak.disable_list_exceptions = False
 
             mr.map(['riak_kv_mapreduce', 'map_object_value'])
 

--- a/aioriak/transport.py
+++ b/aioriak/transport.py
@@ -159,7 +159,7 @@ class RPBStreamParser:
     def tail(self):
         return self._in_buf
 
-    async def __aiter__(self):
+    def __aiter__(self):
         return self
 
     async def __anext__(self):
@@ -195,7 +195,7 @@ class MapRedStream:
         self._phase = None
         self._expect = expect
 
-    async def __aiter__(self):
+    def __aiter__(self):
         return self
 
     async def __anext__(self):


### PR DESCRIPTION
As part of [Python 3.7 Alpha 2](https://docs.python.org/3/whatsnew/changelog.html#python-3-7-0-alpha-2) support for asynchronous `__aiter__` was removed. When trying to use aioriak on 3.7, this results in an error.

This pull request adds support for Python 3.7 and should not harm support to existing Python versions in any way (judging from the tests that is).

However, the `riak` package itself (the one on PyPI) does not support 3.7 due to using a deprecated argument to `namedtuple`, which was only fixed on master. Therefore, if someone wants to use 3.7 with aioriak, installation of `riak` from GitHub is necessary.

Since I'm not entirely sure how to get `setup.py` to install from GitHub for specific versions for testing I have left out an extra CI pipeline for now. There were also two remaining test errors that popped up when testing with the riak-python-client from GitHub due to running bucket & key list operations (see https://github.com/basho/riak-python-client/pull/518). Temporarily setting `riak.disable_list_exceptions = True` in the relevant tests prevents this.