### PR TITLE
Add a connection pool for Python 3.7+, test on 3.7.3 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
 python:
   - '3.5.4'
   - '3.6.4'
+  - '3.7.3'
 
 install:
   - pip install .

--- a/README.rst
+++ b/README.rst
@@ -33,12 +33,12 @@ Riak BucketTypes                    Yes
 Custom resolver                     Yes
 Node list support                   WIP
 Custom quorum                       No
-Connections Pool                    No
+Connections Pool                    Yes
 Operations timeout                  No
 Security                            No
 Riak Search                         WIP
 MapReduce                           WIP
-Tested python versions              `3.5, 3.6 <travis_>`__
+Tested python versions              `3.5, 3.6, 3.7 <travis_>`__
 Tested Riak versions                `2.1.4, 2.2.3 <travis_>`__
 ================================  ==============================
 

--- a/aioriak/pool.py
+++ b/aioriak/pool.py
@@ -1,7 +1,5 @@
 import asyncio
 import logging
-import zlib
-from collections.abc import Mapping
 try:
     from contextlib import asynccontextmanager
 except ImportError as err:  # pragma: no cover - unreachable on 3.7

--- a/aioriak/pool.py
+++ b/aioriak/pool.py
@@ -28,14 +28,13 @@ class ConnectionPool:
         '''
         Set up the connection pool.
 
-        Arguments:
-        :param max_connections: The maximum amount of connections to keep 
-            internally at any time. If this amount of connections is reached
-            and the attempt to acquire a connection is made, the caller will
-            be blocked until a connection from the pool becomes available.
+        :param max_connections: The maximum amount of connections to keep \
+        internally at any time. If this amount of connections is reached \
+        and the attempt to acquire a connection is made, the caller will \
+        be blocked until a connection from the pool becomes available.
         :type max_connections: int
 
-        Any further connection parameters are passed to riak clients when
+        Any further keyword arguments are passed to riak clients when
         a new pool connection is to be established.
         '''
         self.total_connections = 0

--- a/aioriak/pool.py
+++ b/aioriak/pool.py
@@ -1,0 +1,93 @@
+import asyncio
+import logging
+import zlib
+from collections.abc import Mapping
+try:
+    from contextlib import asynccontextmanager
+except ImportError as err:  # pragma: no cover - unreachable on 3.7
+    raise ImportError(
+        "Python 3.7 is required for the connection pool "
+        "via `contextlib.asynccontextmanager`"
+    ) from err
+
+from .client import RiakClient
+
+
+logger = logging.getLogger('aioriak.pool')
+
+
+class ConnectionPool:
+    '''
+    A connection pool for client connections.
+
+    This class maintains an internal list of connections
+    and establishes new connections on demand up
+    until a certain bound.
+    '''
+    def __init__(self, max_connections, **connection_kwargs):
+        '''
+        Set up the connection pool.
+
+        Arguments:
+        :param max_connections: The maximum amount of connections to keep 
+            internally at any time. If this amount of connections is reached
+            and the attempt to acquire a connection is made, the caller will
+            be blocked until a connection from the pool becomes available.
+        :type max_connections: int
+
+        Any further connection parameters are passed to riak clients when
+        a new pool connection is to be established.
+        '''
+        self.total_connections = 0
+        self.max_connections = max_connections
+
+        self._connection_kwargs = connection_kwargs
+        self._ready_connections = []
+        self._semaphore = asyncio.Semaphore(value=self.max_connections)
+
+    def __del__(self):
+        '''Clean up connections to Riak.'''
+        for conn in self._ready_connections:
+            conn.close()
+
+    async def establish_new_connection(self):
+        '''
+        Set up a new connection using the connection factory passed
+        in the constructor and add it to the currently ready connections.
+
+        You normally do not need to call this manually, it is called
+        by the pool to set up a connection in `acquire`.
+        '''
+        new_connection = await RiakClient.create(**self._connection_kwargs)
+        self.total_connections += 1
+        logger.debug(
+            "Established new Riak connection for pool (%d/%d).",
+            self.total_connections, self.max_connections
+        )
+        self._ready_connections.append(new_connection)
+
+    @asynccontextmanager
+    async def acquire(self):
+        '''
+        Acquire a connection from the pool.
+        If the pool is not at its full capacity, add a new connection to it.
+        Otherwise, return one as soon as it becomes available.
+
+        :Example:
+
+        .. code-block:: python
+
+            async with my_pool.acquire() as conn:
+                bucket = conn.bucket('example')
+                obj = await bucket.get('users:by-name:testuser')
+        '''
+        async with self._semaphore:
+
+            if self.total_connections < self.max_connections:
+                await self.establish_new_connection()
+
+            acquired_connection = self._ready_connections.pop()
+            try:
+                yield acquired_connection
+            finally:
+                self._ready_connections.append(acquired_connection)

--- a/aioriak/tests/test_kv.py
+++ b/aioriak/tests/test_kv.py
@@ -4,9 +4,10 @@ from aioriak.mapreduce import RiakMapReduce
 from aioriak.error import ConflictError
 from aioriak.resolver import default_resolver, last_written_resolver
 import asyncio
+import copy
 import json
 import pickle
-import copy
+import riak
 
 
 testrun_props_bucket = 'propsbucket'
@@ -662,7 +663,11 @@ class BasicKVTests(IntegrationTest, AsyncUnitTestCase):
                                     {'foo': 'two', 'bar': 'green'})).store()
 
             mr = RiakMapReduce(self.client)
-            mr.add_bucket(self.bucket_name)
+            try:
+                riak.disable_list_exceptions = True
+                mr.add_bucket(self.bucket_name)
+            finally:
+                riak.disable_list_exceptions = False
 
             mr.map(['riak_kv_mapreduce', 'map_object_value'])
 
@@ -681,7 +686,12 @@ class BasicKVTests(IntegrationTest, AsyncUnitTestCase):
                                     {'foo': 'two', 'bar': 'green'})).store()
 
             mr = RiakMapReduce(self.client)
-            mr.add_bucket(self.bucket_name)
+
+            try:
+                riak.disable_list_exceptions = True
+                mr.add_bucket(self.bucket_name)
+            finally:
+                riak.disable_list_exceptions = False
 
             mr.map(['riak_kv_mapreduce', 'map_object_value'])
 

--- a/aioriak/tests/test_pool.py
+++ b/aioriak/tests/test_pool.py
@@ -1,0 +1,61 @@
+import sys
+import unittest
+
+from aioriak.tests.base import AsyncUnitTestCase, IntegrationTest
+
+
+@unittest.skipIf(
+    sys.version_info < (3, 7),
+    "requires Python 3.7 for contextlib.asynccontextmanager"
+)
+class PoolTests(IntegrationTest, AsyncUnitTestCase):
+    def test_does_not_exceed_pool_size(self):
+        async def go():
+            from aioriak.pool import ConnectionPool
+
+            pool = ConnectionPool(
+                max_connections=2,
+                host=self.client._host
+            )
+            for _ in range(5):
+                async with pool.acquire() as conn:
+                    pong = await conn.ping()
+                    self.assertTrue(pong)
+
+            self.assertEqual(pool.total_connections, 2)
+            self.assertEqual(pool.max_connections, 2)
+            self.assertEqual(len(pool._ready_connections), 2)
+
+        self.loop.run_until_complete(go())
+
+    def test_pops_from_ready_connections(self):
+        async def go():
+            from aioriak.pool import ConnectionPool
+
+            pool = ConnectionPool(
+                max_connections=2,
+                host=self.client._host
+            )
+
+            async with pool.acquire() as conn:
+                self.assertNotIn(conn, pool._ready_connections)
+            self.assertIn(conn, pool._ready_connections)
+
+        self.loop.run_until_complete(go())
+
+    def test_adds_connections_one_by_one(self):
+        async def go():
+            from aioriak.pool import ConnectionPool
+
+            pool = ConnectionPool(
+                max_connections=10,
+                host=self.client._host
+            )
+
+            for n in range(10):
+                async with pool.acquire() as conn:
+                    pong = await conn.ping()
+                    self.assertTrue(pong)
+                    self.assertEqual(pool.total_connections, n + 1)
+
+        self.loop.run_until_complete(go())

--- a/aioriak/transport.py
+++ b/aioriak/transport.py
@@ -159,7 +159,7 @@ class RPBStreamParser:
     def tail(self):
         return self._in_buf
 
-    async def __aiter__(self):
+    def __aiter__(self):
         return self
 
     async def __anext__(self):
@@ -195,7 +195,7 @@ class MapRedStream:
         self._phase = None
         self._expect = expect
 
-    async def __aiter__(self):
+    def __aiter__(self):
         return self
 
     async def __anext__(self):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,12 +20,12 @@ Riak BucketTypes                    Yes
 Custom resolver                     Yes
 Node list support                   WIP
 Custom quorum                       No
-Connections Pool                    No
+Connections Pool                    Yes
 Operations timout                   No
 Security                            No
 Riak Search                         WIP
 MapReduce                           WIP
-Tested python versions              `3.5, 3.6 <travis_>`__
+Tested python versions              `3.5, 3.6, 3.7 <travis_>`__
 Tested Riak versions                `2.1.3, 2.1.4 <travis_>`__
 ================================  ==============================
 
@@ -65,6 +65,7 @@ Contents
     :maxdepth: 4
     
     client
+    pool
     bucket
     object
     datatypes

--- a/docs/pool.rst
+++ b/docs/pool.rst
@@ -1,0 +1,19 @@
+.. highlight:: python
+
+.. currentmodule:: aioriak.pool
+
+===============
+Connection Pool
+===============
+
+For Python 3.7+, aioriak brings a connection pool class which
+internally manages a configured amount of Riak connections. Connections
+are opened on-demand and a semaphore is used to ensure that connections
+are used only by one caller at a time.
+
+----------------------
+ConnectionPool objects
+----------------------
+
+.. autoclass:: ConnectionPool
+   :members: __init__, acquire, establish_new_connection

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-riak==2.7.0
+riak==2.7.0;python_version<'3.7'
+riak @ https://github.com/basho/riak-python-client/archive/master.zip;python_version>='3.7'


### PR DESCRIPTION
While initially testing this library I realized that the client cannot deal with multiple asynchronous tasks accessing it at the same time which happens quite a bit in our setup, so a connection pool was created.

To me the `asynccontextmanager` seems like the cleanest solution, but unfortunately it's only available from 3.7.3+. For our code this was no problem, but if you have a better suggestion that also works for earlier Python versions I'd be happy to change it.

To make the library work on 3.7, this PR was rebased off #75, which may mess up the diff a bit.

There is another issue I'm not sure on how to fix - as outlined in #75 to get 3.7 compat users need to install the Riak library from GitHub, but I'm a bit confused how to trick `setup.py` into installing the GItHub version for the tests only. Right now from my understanding it will install the riak library from GitHub for all users that run on 3.7, and the current setup also requires PyPI 18.1+.